### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ try it as follows
 
 
 here is the code:
-
+```
 import numpy as np
 
 import pylab as pl
@@ -38,5 +38,5 @@ plotwresids(x,y,res,xlabel= "fake data",ylabel="sin-ish", legend="made up stuff"
 plotwresids([x,x1],[y,y1],[res,res1],err=[None,np.sqrt(np.abs(np.sin(x1)))],xlabel= "fake data",ylabel="sin-ish",scatter=[True,True], color=['SteelBlue','DarkOrange'], legend=["madeup stuff","more madeup stuff"])
 
 pl.show()
-
+```
 


### PR DESCRIPTION
I noticed that there were two missing multiplication signs in your sine example residual plot on the readme. This is because of a quirk in the markdown styling where two asterisks (*) creates italics. When I add the code block formatting the viewer can now see the multiplication signs.
